### PR TITLE
Fix rendering of muscle SVG icons

### DIFF
--- a/InnovaFit/Views/MuscleListView.swift
+++ b/InnovaFit/Views/MuscleListView.swift
@@ -21,7 +21,7 @@ struct MuscleListView: View {
     
     var muscleIcons: some View {
         HStack(spacing: 32) {
-            ForEach(sortedMuscles.prefix(3)) { item in
+            ForEach(sortedMuscles) { item in
                 if let uiImage = svgLoader.images[item.name] {
                     Image(uiImage: uiImage)
                         .resizable()


### PR DESCRIPTION
## Summary
- show all muscle icons without limiting to 3 in `MuscleListView`

## Testing
- `swift test -v` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_6849a46e5f508330ad5fe2b78deb85a0