### PR TITLE
Add cancelable SVG loading

### DIFF
--- a/InnovaFit/Views/MuscleListView.swift
+++ b/InnovaFit/Views/MuscleListView.swift
@@ -62,6 +62,7 @@ struct MuscleListView: View {
 
         }
         .onChange(of: musclesWorked) { _ in
+            svgLoader.cancelAllTasks()
             svgLoader.images.removeAll()
             svgLoader.loadSVGs(muscles: sortedMuscles, gymColorHex: gymColor.toHex())
         }


### PR DESCRIPTION
## Summary
- keep an array of loading `Task` objects in `SVGImageLoader`
- add `cancelAllTasks()` to stop all running loads
- cancel running tasks whenever muscles change

## Testing
- `swift test` *(fails: Package.swift not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a10c31e008330bf360bccb061e52e