### PR TITLE
Add debug prints to track muscle list changes

### DIFF
--- a/InnovaFit/Views/MachineScreenContent.swift
+++ b/InnovaFit/Views/MachineScreenContent.swift
@@ -31,6 +31,10 @@ struct MachineScreenContent: View {
                         gymColor: gym.safeColor,
                         onVideoDismissed: { _ in handleVideoDismiss() },
                         onVideoChanged: { video in
+                            print("🎞️ onVideoChanged -> \(video.title)")
+                            video.musclesWorked.forEach { key, value in
+                                print("   - \(key): \(value.icon)")
+                            }
                             selectedVideo = video
                         }
                     )
@@ -53,6 +57,12 @@ struct MachineScreenContent: View {
                     // ✅ Inicializar al cargar la vista
                     if selectedVideo == nil {
                         selectedVideo = machine.defaultVideos.first
+                        if let video = selectedVideo {
+                            print("🆗 selectedVideo inicial: \(video.title)")
+                            video.musclesWorked.forEach { key, value in
+                                print("   - \(key): \(value.icon)")
+                            }
+                        }
                     }
                     
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -74,6 +84,16 @@ struct MachineScreenContent: View {
                             dismissFeedback()
                         }
                     )
+                }
+                .onChange(of: selectedVideo) { newVideo in
+                    if let video = newVideo {
+                        print("📹 MachineScreenContent - selectedVideo cambiado: \(video.title)")
+                        video.musclesWorked.forEach { key, value in
+                            print("   - \(key): \(value.icon)")
+                        }
+                    } else {
+                        print("📹 MachineScreenContent - selectedVideo es nil")
+                    }
                 }
             }
         }

--- a/InnovaFit/Views/MuscleListView.swift
+++ b/InnovaFit/Views/MuscleListView.swift
@@ -56,12 +56,19 @@ struct MuscleListView: View {
         .padding()
         .onAppear {
             print("🧠 MuscleListView - Recibido musclesWorked:")
-                musclesWorked.forEach { print("🔸 \($0.key): \($0.value.icon)") }
+            musclesWorked.forEach { key, value in
+                print("🔸 \(key): \(value.icon)")
+            }
 
             svgLoader.loadSVGs(muscles: sortedMuscles, gymColorHex: gymColor.toHex())
 
         }
-        .onChange(of: musclesWorked) { _ in
+        .onChange(of: musclesWorked) { newMuscles in
+            print("🔄 MuscleListView - musclesWorked actualizado:")
+            newMuscles.forEach { key, value in
+                print("🔸 \(key): \(value.icon)")
+            }
+
             svgLoader.images.removeAll()
             svgLoader.loadSVGs(muscles: sortedMuscles, gymColorHex: gymColor.toHex())
         }


### PR DESCRIPTION
## Summary
- log all muscles when a video changes in `MachineScreenContent`
- log initial muscle list on appear
- show logs when `MuscleListView` appears and whenever its `musclesWorked` input changes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684a1b41e0108330a949d3497f817010