### PR TITLE
Add tests for carousel updates and SVG icons

### DIFF
--- a/InnovaFit/Utils/Inspection.swift
+++ b/InnovaFit/Utils/Inspection.swift
@@ -1,0 +1,13 @@
+import Combine
+import SwiftUI
+
+internal final class Inspection<V> {
+    let notice = PassthroughSubject<UInt, Never>()
+    var callbacks: [UInt: (V) -> Void] = [:]
+
+    func visit(_ view: V, _ line: UInt) {
+        if let callback = callbacks.removeValue(forKey: line) {
+            callback(view)
+        }
+    }
+}

--- a/InnovaFit/Views/VideoCarouselView.swift
+++ b/InnovaFit/Views/VideoCarouselView.swift
@@ -2,12 +2,14 @@ import SwiftUI
 import SDWebImageSwiftUI
 
 struct VideoCarouselView: View {
-    
+
     let videos: [Video]
     let gymColor: String
     var onVideoDismissed: ((Video) -> Void)? = nil
     var onVideoChanged: ((Video) -> Void)? = nil
-    
+
+    internal let inspection = Inspection<Self>()
+
     @State private var scrollPosition: Int?
     @State private var itemsArray: [[Video]] = []
     @State private var selectedVideo: Video?
@@ -114,6 +116,7 @@ struct VideoCarouselView: View {
                 )
             }
         }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
     }
 }
 

--- a/InnovaFitTests/Inspection+Emissary.swift
+++ b/InnovaFitTests/Inspection+Emissary.swift
@@ -1,0 +1,3 @@
+import ViewInspector
+@testable import InnovaFit
+extension Inspection: InspectionEmissary {}

--- a/InnovaFitTests/Resources/test.svg
+++ b/InnovaFitTests/Resources/test.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path d="M50 10 L90 90 H10 Z" fill="#ff004f"/>
+</svg>

--- a/InnovaFitTests/SVGImageLoaderTests.swift
+++ b/InnovaFitTests/SVGImageLoaderTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import InnovaFit
+
+final class SVGImageLoaderTests: XCTestCase {
+    func testLoadSVGTransformsAndStoresImage() async throws {
+        let loader = SVGImageLoader()
+        guard let url = Bundle.module.url(forResource: "test", withExtension: "svg", subdirectory: "Resources") else {
+            XCTFail("Resource not found")
+            return
+        }
+        let muscle = MuscleWithName(_id: "1", name: "Test", muscle: Muscle(weight: 50, icon: url.absoluteString))
+        loader.loadSVGs(muscles: [muscle], gymColorHex: "#123456")
+
+        let expectation = XCTestExpectation(description: "Image loaded")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 5)
+
+        XCTAssertNotNil(loader.images["Test"])
+    }
+}

--- a/InnovaFitTests/VideoCarouselViewTests.swift
+++ b/InnovaFitTests/VideoCarouselViewTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import ViewInspector
+@testable import InnovaFit
+
+extension VideoCarouselView: Inspectable {}
+
+final class VideoCarouselViewTests: XCTestCase {
+    func testOnVideoChangedTriggeredWhenScrollUpdates() throws {
+        let videos = PreviewFactory.sampleMachine.defaultVideos
+        var received: Video?
+        var sut = VideoCarouselView(videos: videos, gymColor: "#FFFFFF", onVideoChanged: { video in
+            received = video
+        })
+
+        let expAppear = sut.inspection.inspect { view in
+            XCTAssertEqual(try view.actualView().scrollPosition, videos.count)
+            try view.actualView().scrollPosition = videos.count + 1
+            sut.inspection.notice.send(1)
+        }
+
+        let expChange = sut.inspection.inspect(after: 0.1) { _ in
+            XCTAssertEqual(received, videos[1])
+        }
+
+        ViewHosting.host(view: sut)
+        wait(for: [expAppear, expChange], timeout: 1.0)
+        ViewHosting.expel()
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ let package = Package(
     platforms: [
         .iOS(.v17)
     ],
+    dependencies: [
+        .package(url: "https://github.com/nalexn/ViewInspector", from: "0.9.8")
+    ],
     targets: [
         .executableTarget(
             name: "InnovaFit",
@@ -13,8 +16,11 @@ let package = Package(
         ),
         .testTarget(
             name: "InnovaFitTests",
-            dependencies: ["InnovaFit"],
-            path: "InnovaFitTests"
+            dependencies: ["InnovaFit", "ViewInspector"],
+            path: "InnovaFitTests",
+            resources: [
+                .copy("Resources")
+            ]
         )
     ]
 )


### PR DESCRIPTION
## Summary
- add Inspection helper and integrate into VideoCarouselView
- add ViewInspector test helpers
- include sample svg test resource
- add unit tests verifying carousel update callbacks and svg processing

## Testing
- `swift test --enable-code-coverage` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_684a3a7c44748330b5bbc155a2767064