### PR TITLE
Add QR scanner for manual launch

### DIFF
--- a/InnovaFit/Info.plist
+++ b/InnovaFit/Info.plist
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict/>
+        <key>NSAppTransportSecurity</key>
+        <dict/>
+        <key>NSCameraUsageDescription</key>
+        <string>Se necesita acceso a la cámara para escanear el código QR de InnovaFit.</string>
 </dict>
 </plist>

--- a/InnovaFit/InnovaFitApp.swift
+++ b/InnovaFit/InnovaFitApp.swift
@@ -6,8 +6,9 @@ import FirebaseCore
 
 // MARK: - AppDelegate con soporte para Universal Links
 class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
-    
+
     @Published var pendingTag: String?
+    @Published var didLaunchViaUniversalLink: Bool = false
     
     func application(
         _ application: UIApplication,
@@ -15,6 +16,17 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
     ) -> Bool {
         print("🚀 AppDelegate: aplicación lanzó")
         FirebaseApp.configure()
+        if let activities = launchOptions?[.userActivityDictionary] as? [AnyHashable: Any],
+           let activity = activities.values.first as? NSUserActivity,
+           activity.activityType == NSUserActivityTypeBrowsingWeb,
+           let url = activity.webpageURL,
+           let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+           let tag = components.queryItems?.first(where: { $0.name == "tag" })?.value {
+            pendingTag = tag
+            didLaunchViaUniversalLink = true
+        } else {
+            didLaunchViaUniversalLink = false
+        }
         return true
     }
     
@@ -26,9 +38,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
            let url = userActivity.webpageURL,
            let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
            let tag = components.queryItems?.first(where: { $0.name == "tag" })?.value {
-            
+
             print("📲 AppDelegate recibió tag por Universal Link: \(tag)")
             self.pendingTag = tag
+            didLaunchViaUniversalLink = true
             return true
         }
         

--- a/InnovaFit/Views/AccessRestrictedView.swift
+++ b/InnovaFit/Views/AccessRestrictedView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AccessRestrictedView: View {
-    var onDismiss: () -> Void
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(spacing: 24) {
@@ -22,7 +22,7 @@ struct AccessRestrictedView: View {
                 .frame(maxWidth: 250)
                 .padding(.bottom, 16)
 
-            Button(action: onDismiss) {
+            Button(action: { dismiss() }) {
                 Text("Cerrar")
                     .foregroundColor(Color(hex: "#FDD835"))
                     .fontWeight(.bold)

--- a/InnovaFit/Views/QRScannerView.swift
+++ b/InnovaFit/Views/QRScannerView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import AVFoundation
+
+struct QRScannerView: UIViewControllerRepresentable {
+    var onFound: (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIViewController(context: Context) -> ScannerViewController {
+        let controller = ScannerViewController()
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) { }
+
+    class Coordinator: NSObject, ScannerViewControllerDelegate {
+        let parent: QRScannerView
+        init(parent: QRScannerView) { self.parent = parent }
+        func didFind(code: String) {
+            parent.onFound(code)
+        }
+    }
+}
+
+protocol ScannerViewControllerDelegate: AnyObject {
+    func didFind(code: String)
+}
+
+class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+    weak var delegate: ScannerViewControllerDelegate?
+    private let captureSession = AVCaptureSession()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureSession()
+    }
+
+    private func configureSession() {
+        guard let videoDevice = AVCaptureDevice.default(for: .video),
+              let videoInput = try? AVCaptureDeviceInput(device: videoDevice),
+              captureSession.canAddInput(videoInput) else { return }
+
+        captureSession.addInput(videoInput)
+
+        let metadataOutput = AVCaptureMetadataOutput()
+        guard captureSession.canAddOutput(metadataOutput) else { return }
+
+        captureSession.addOutput(metadataOutput)
+        metadataOutput.setMetadataObjectsDelegate(self, queue: DispatchQueue.main)
+        metadataOutput.metadataObjectTypes = [.qr]
+
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
+        previewLayer.videoGravity = .resizeAspectFill
+        previewLayer.frame = view.layer.bounds
+        view.layer.addSublayer(previewLayer)
+
+        captureSession.startRunning()
+    }
+
+    func metadataOutput(_ output: AVCaptureMetadataOutput,
+                        didOutput metadataObjects: [AVMetadataObject],
+                        from connection: AVCaptureConnection) {
+        guard let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              object.type == .qr,
+              let stringValue = object.stringValue else { return }
+        delegate?.didFind(code: stringValue)
+    }
+}


### PR DESCRIPTION
## Summary
- add camera permission to Info.plist
- add QRScannerView for scanning QR codes
- track universal link launches in AppDelegate
- show QR scanner on manual launch
- avoid force exiting the app

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e2284bac8330a534c39a07408c28