### PR TITLE
Fix AuthViewModel init logic

### DIFF
--- a/InnovaFit/ViewModels/AuthViewModel.swift
+++ b/InnovaFit/ViewModels/AuthViewModel.swift
@@ -22,6 +22,19 @@ class AuthViewModel: ObservableObject {
 
     init() {
         loadGyms()
+        if let uid = Auth.auth().currentUser?.uid {
+            repository.fetchUserProfile(uid: uid) { [weak self] result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let profile):
+                        self?.userProfile = profile
+                        self?.authState = .home
+                    case .failure:
+                        self?.authState = .register
+                    }
+                }
+            }
+        }
     }
 
     /// Envía el código OTP al número de teléfono


### PR DESCRIPTION
## Summary
- look up current Firebase user when creating `AuthViewModel`
- fetch the corresponding profile and set `authState` accordingly

## Testing
- `./run_tests.sh` *(fails: `xcodebuild` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac30d09c83308a8d2844fde48dc6