### PR TITLE
Add logout support

### DIFF
--- a/InnovaFit/ViewModels/AuthViewModel.swift
+++ b/InnovaFit/ViewModels/AuthViewModel.swift
@@ -80,4 +80,19 @@ class AuthViewModel: ObservableObject {
             }
         }
     }
+
+    /// Cierra la sesión del usuario actual y vuelve al estado de login
+    func signOut() {
+        do {
+            try Auth.auth().signOut()
+            // Restablecer propiedades relevantes
+            phoneNumber = ""
+            otpCode = ""
+            verificationID = nil
+            userProfile = nil
+            authState = .login
+        } catch {
+            print("❌ Error al cerrar sesión: \(error.localizedDescription)")
+        }
+    }
 }

--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -23,6 +23,16 @@ struct HomeView: View {
                         machineVM.loadMachines(forGymId: gymId)
                     }
                 }
+
+                Button("Cerrar sesión") {
+                    viewModel.signOut()
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color(hex: "#00C2FF"))
+                .foregroundColor(.white)
+                .cornerRadius(12)
+                .padding(.horizontal)
             }
         }
         .background(Color.white)


### PR DESCRIPTION
## Summary
- add `signOut()` helper to `AuthViewModel` to reset auth state
- display a logout button in `HomeView`

## Testing
- `./run_tests.sh` *(fails: xcodebuild: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868ac3983188330801ee9adcebe91c4