### PR TITLE
Add gymId to UserProfile

### DIFF
--- a/InnovaFit/Models/UserProfile.swift
+++ b/InnovaFit/Models/UserProfile.swift
@@ -7,6 +7,9 @@ struct UserProfile: Codable, Identifiable {
     let phoneNumber: String
     let age: Int
     let gender: Gender
+    /// Identificador del gimnasio al que pertenece el usuario
+    let gymId: String
+    /// Información básica del gimnasio (sin el id de documento)
     let gym: Gym
     var weight: Double
     var height: Double

--- a/InnovaFit/ViewModels/AuthViewModel.swift
+++ b/InnovaFit/ViewModels/AuthViewModel.swift
@@ -102,6 +102,7 @@ class AuthViewModel: ObservableObject {
             phoneNumber: phone,
             age: age,
             gender: gender,
+            gymId: gym.id ?? "",
             gym: gym,
             weight: weight,
             height: height

--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -40,7 +40,7 @@ struct HomeView: View {
                 .padding(.horizontal)
                 .padding(.top)
                 .onAppear {
-                    if let gymId = viewModel.userProfile?.gym.id {
+                    if let gymId = viewModel.userProfile?.gymId {
                         machineVM.loadMachines(forGymId: gymId)
                     }
                 }
@@ -140,6 +140,7 @@ class Mock2AuthViewModel: AuthViewModel {
             phoneNumber: "+51999999999",
             age: 25,
             gender: .masculino,
+            gymId: "gym_001",
             gym: Gym(id: "gym_001",
                      address: "Av. Ejemplo 123",
                      color: "#FFD600",


### PR DESCRIPTION
## Summary
- add `gymId` field in `UserProfile`
- capture gym id when registering user
- use `gymId` when loading machines in `HomeView`
- update preview mocks

## Testing
- `swift build -c release` *(fails: no such module 'SwiftUI')*
- `./run_tests.sh` *(fails: xcodebuild: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcf5c2c008330ae9fc48cd770f524