### PR TITLE
Fix gym ID usage and navigation

### DIFF
--- a/InnovaFit/Models/UserProfile.swift
+++ b/InnovaFit/Models/UserProfile.swift
@@ -7,7 +7,12 @@ struct UserProfile: Codable, Identifiable {
     let phoneNumber: String
     let age: Int
     let gender: String
-    let gym: Gym
+    /// Identificador real del gimnasio asociado
+    let gymId: String
+    /// Datos del gimnasio. Al decodificar desde Firestore el campo `id` puede
+    /// no contener el valor correcto, por lo que se usa `gymId` como fuente de
+    /// verdad.
+    var gym: Gym?
     var weight: Double
     var height: Double
 }

--- a/InnovaFit/Repository/UserRepository.swift
+++ b/InnovaFit/Repository/UserRepository.swift
@@ -28,7 +28,12 @@ class UserRepository {
                 return
             }
             do {
-                let profile = try doc.data(as: UserProfile.self)
+                var profile = try doc.data(as: UserProfile.self)
+                // Asegurar que el gimnasio tenga el ID correcto
+                if var gym = profile.gym {
+                    gym.id = profile.gymId
+                    profile.gym = gym
+                }
                 completion(.success(profile))
             } catch {
                 completion(.failure(error))

--- a/InnovaFit/ViewModels/AuthViewModel.swift
+++ b/InnovaFit/ViewModels/AuthViewModel.swift
@@ -107,6 +107,7 @@ class AuthViewModel: ObservableObject {
             phoneNumber: phone,
             age: age,
             gender: gender,
+            gymId: gym.id ?? "",
             gym: gym,
             weight: weight,
             height: height

--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -5,7 +5,6 @@ struct HomeView: View {
     @ObservedObject var viewModel: AuthViewModel
     @StateObject private var machineVM = MachineViewModel()
     @State private var isPresentingScanner = false
-    @State private var selectedMachine: Machine?
 
     var body: some View {
         NavigationStack {
@@ -43,24 +42,16 @@ struct HomeView: View {
 
                             // 🛠️ Lista de máquinas
                             ForEach(machineVM.machines) { machine in
-                                MachineCardView(machine: machine) {
-                                    selectedMachine = machine
-                                }
-                            }
-
-                            // Enlace oculto para navegación
-                            if let machine = selectedMachine {
                                 NavigationLink(value: machine) {
-                                    EmptyView()
+                                    MachineCardView(machine: machine)
                                 }
-                                .hidden()
                             }
                         }
                     }
                     .padding(.horizontal)
                     .padding(.top)
                     .onAppear {
-                        if let gymId = viewModel.userProfile?.gym.id {
+                        if let gymId = viewModel.userProfile?.gymId {
                             machineVM.loadMachines(forGymId: gymId)
                         }
                     }
@@ -102,7 +93,6 @@ struct HomeView: View {
 
 struct MachineCardView: View {
     let machine: Machine
-    let onTutorialTap: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -132,18 +122,16 @@ struct MachineCardView: View {
                 .cornerRadius(10)
             }
 
-            Button(action: onTutorialTap) {
-                HStack {
-                    Text("Ver tutorial")
-                    Image(systemName: "arrow.right")
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(Color(hex: "#F5F5F0"))
-                .foregroundColor(.textTitle)
-                .cornerRadius(8)
-                .font(.system(size: 14, weight: .semibold))
+            HStack {
+                Text("Ver tutorial")
+                Image(systemName: "arrow.right")
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color(hex: "#F5F5F0"))
+            .foregroundColor(.textTitle)
+            .cornerRadius(8)
+            .font(.system(size: 14, weight: .semibold))
         }
         .padding()
         .background(Color.white)


### PR DESCRIPTION
## Summary
- keep real gym id in `UserProfile` using new `gymId` field
- load machines using `gymId`
- ensure decoded gym has proper id in `UserRepository`
- navigate to machine detail directly from machine list

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d54d109a083308233b1906156f4f1