### PR TITLE
Enable back gesture navigation

### DIFF
--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -72,11 +72,16 @@ struct HomeView: View {
                     .cornerRadius(28)
                 }
                 .padding()
-                .fullScreenCover(isPresented: $isPresentingScanner) {
+
+                NavigationLink(isActive: $isPresentingScanner) {
                     QRScannerView { scannedCode in
                         print("📦 Código escaneado: \(scannedCode)")
                         isPresentingScanner = false
                     }
+                    .navigationTitle("Escanear QR")
+                    .navigationBarTitleDisplayMode(.inline)
+                } label: {
+                    EmptyView()
                 }
             }
             .background(Color.white.ignoresSafeArea())

--- a/InnovaFit/Views/MachineScreenContent.swift
+++ b/InnovaFit/Views/MachineScreenContent.swift
@@ -126,7 +126,6 @@ struct MachineScreenContent: View {
             }
             .background(Color.white)
             .ignoresSafeArea(edges: .bottom)
-            .navigationBarBackButtonHidden(true)
         }
 
     private var header: some View {


### PR DESCRIPTION
## Summary
- present QRScannerView with NavigationLink so iOS back swipe works
- allow default navigation bar on MachineScreenContent

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de14551c483308f0bc2bcc8ae1a00