### PR TITLE
Allow swipe back with hidden navigation bar

### DIFF
--- a/InnovaFit/Utils/SwipeBackNavigation.swift
+++ b/InnovaFit/Utils/SwipeBackNavigation.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// A container that hides the navigation bar but keeps the swipe-to-go-back gesture.
+struct SwipeBackNavigation<Content: View>: UIViewControllerRepresentable {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let hosting = UIHostingController(rootView: content)
+        let navController = UINavigationController(rootViewController: hosting)
+        navController.interactivePopGestureRecognizer?.delegate = context.coordinator
+        navController.setNavigationBarHidden(true, animated: false)
+        return navController
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+        if let hosting = uiViewController.topViewController as? UIHostingController<Content> {
+            hosting.rootView = content
+        }
+        uiViewController.setNavigationBarHidden(true, animated: false)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+}

--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -82,20 +82,20 @@ struct HomeView: View {
             .navigationDestination(for: NavigationRoute.self) { route in
                 switch route {
                 case .qrScanner:
-                    QRScannerView { scannedCode in
-                        print("📦 Código escaneado: \(scannedCode)")
-                        navigationPath.removeLast() // volver automáticamente
+                    SwipeBackNavigation {
+                        QRScannerView { scannedCode in
+                            print("📦 Código escaneado: \(scannedCode)")
+                            navigationPath.removeLast() // volver automáticamente
+                        }
                     }
-                    .navigationTitle("")
-                    .navigationBarTitleDisplayMode(.inline)
-                    //.navigationBarBackButtonHidden(true)
+                    .navigationBarHidden(true)
 
                 case .machine(let machine):
                     if let gym = viewModel.userProfile?.gym {
-                        MachineScreenContent(machine: machine, gym: gym)
-                            .navigationTitle("")
-                            .navigationBarTitleDisplayMode(.inline)
-                            //.navigationBarBackButtonHidden(true)
+                        SwipeBackNavigation {
+                            MachineScreenContent(machine: machine, gym: gym)
+                        }
+                        .navigationBarHidden(true)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add SwipeBackNavigation helper to keep interactive pop gesture while hiding the bar
- wrap QR scanner and machine views with SwipeBackNavigation

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686de9aef3908330a1b2788c1d2c0c14