### PR TITLE
Allow swipe-back without showing nav bar

### DIFF
--- a/InnovaFit/Utils/SwipeBackNavigation.swift
+++ b/InnovaFit/Utils/SwipeBackNavigation.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Container to hide the navigation bar while keeping the swipe back gesture
+/// of the parent `UINavigationController`.
+struct SwipeBackNavigation<Content: View>: UIViewControllerRepresentable {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    func makeUIViewController(context: Context) -> UIHostingController<Content> {
+        let hosting = UIHostingController(rootView: content)
+        hosting.view.backgroundColor = .clear
+        return hosting
+    }
+
+    func updateUIViewController(_ uiViewController: UIHostingController<Content>, context: Context) {
+        uiViewController.rootView = content
+
+        if let navigationController = uiViewController.navigationController {
+            navigationController.setNavigationBarHidden(true, animated: false)
+            navigationController.interactivePopGestureRecognizer?.delegate = context.coordinator
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            true
+        }
+    }
+}

--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -82,20 +82,20 @@ struct HomeView: View {
             .navigationDestination(for: NavigationRoute.self) { route in
                 switch route {
                 case .qrScanner:
-                    QRScannerView { scannedCode in
-                        print("📦 Código escaneado: \(scannedCode)")
-                        navigationPath.removeLast() // volver automáticamente
+                    SwipeBackNavigation {
+                        QRScannerView { scannedCode in
+                            print("📦 Código escaneado: \(scannedCode)")
+                            navigationPath.removeLast() // volver automáticamente
+                        }
                     }
-                    .navigationTitle("")
-                    .navigationBarTitleDisplayMode(.inline)
-                    //.navigationBarBackButtonHidden(true)
+                    .navigationBarHidden(true)
 
                 case .machine(let machine):
                     if let gym = viewModel.userProfile?.gym {
-                        MachineScreenContent(machine: machine, gym: gym)
-                            .navigationTitle("")
-                            .navigationBarTitleDisplayMode(.inline)
-                            //.navigationBarBackButtonHidden(true)
+                        SwipeBackNavigation {
+                            MachineScreenContent(machine: machine, gym: gym)
+                        }
+                        .navigationBarHidden(true)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- adjust SwipeBackNavigation so it uses the parent navigation controller instead of creating a new one

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*
- `swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_686de9aef3908330a1b2788c1d2c0c14