### PR TITLE
Allow swipe gesture with hidden nav bar

### DIFF
--- a/InnovaFit/Views/HomeView.swift
+++ b/InnovaFit/Views/HomeView.swift
@@ -86,16 +86,12 @@ struct HomeView: View {
                         print("📦 Código escaneado: \(scannedCode)")
                         navigationPath.removeLast() // volver automáticamente
                     }
-                    .navigationTitle("")
-                    .navigationBarTitleDisplayMode(.inline)
-                    //.navigationBarBackButtonHidden(true)
+                    .toolbar(.hidden, for: .navigationBar)
 
                 case .machine(let machine):
                     if let gym = viewModel.userProfile?.gym {
                         MachineScreenContent(machine: machine, gym: gym)
-                            .navigationTitle("")
-                            .navigationBarTitleDisplayMode(.inline)
-                            //.navigationBarBackButtonHidden(true)
+                            .toolbar(.hidden, for: .navigationBar)
                     }
                 }
             }

--- a/InnovaFit/Views/MachineScreenContent.swift
+++ b/InnovaFit/Views/MachineScreenContent.swift
@@ -126,7 +126,7 @@ struct MachineScreenContent: View {
             }
             .background(Color.white)
             .ignoresSafeArea(edges: .bottom)
-            //.navigationBarBackButtonHidden(true)
+            .toolbar(.hidden, for: .navigationBar)
         }
 
     private var header: some View {


### PR DESCRIPTION
## Summary
- remove custom SwipeBackNavigation wrapper
- hide the navigation bar with `.toolbar(.hidden)` in destinations so the swipe-back gesture still works

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686de9aef3908330a1b2788c1d2c0c14