### PR TITLE
Fix MachineScreenContent2 background

### DIFF
--- a/InnovaFit/Views/MachineScreenContent2.swift
+++ b/InnovaFit/Views/MachineScreenContent2.swift
@@ -66,6 +66,7 @@ struct MachineScreenContent2: View {
             .padding(.vertical)
         }
         .background(Color.white)
+        .ignoresSafeArea(edges: .bottom)
         .navigationTitle(machine.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {


### PR DESCRIPTION
## Summary
- fix MachineScreenContent2 background so the white color covers the whole screen

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea08542988330bf0894a560eb2bc9