### PR TITLE
Add Firestore feedback saving

### DIFF
--- a/InnovaFit/Repository/FeedbackRepository.swift
+++ b/InnovaFit/Repository/FeedbackRepository.swift
@@ -1,0 +1,30 @@
+import Foundation
+import FirebaseFirestore
+
+class FeedbackRepository {
+    static func saveFeedback(
+        gymId: String,
+        rating: Int,
+        answer: String,
+        comment: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        let db = Firestore.firestore()
+        var data: [String: Any] = [
+            "answer": answer,
+            "comment": comment,
+            "gymId": gymId,
+            "os": "IOS",
+            "rating": rating,
+            "timestamp": FieldValue.serverTimestamp()
+        ]
+
+        db.collection("feedback").addDocument(data: data) { error in
+            if let error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+}

--- a/InnovaFit/Views/FeedbackDialogView.swift
+++ b/InnovaFit/Views/FeedbackDialogView.swift
@@ -138,7 +138,21 @@ struct FeedbackDialogView: View {
     private var submitButton: some View {
         Button(action: {
             print("📤 Feedback enviado: \(rating) stars, option: \(selectedOption), comment: \(comment)")
-            onFeedbackSent()
+            FeedbackRepository.saveFeedback(
+                gymId: gymId,
+                rating: rating,
+                answer: selectedOption,
+                comment: comment
+            ) { result in
+                switch result {
+                case .success:
+                    print("✅ Feedback guardado en Firestore")
+                    onFeedbackSent()
+                case .failure(let error):
+                    print("⚠️ Error al guardar feedback: \(error)")
+                    onFeedbackSent()
+                }
+            }
         }) {
             Text("Enviar")
                 .font(.headline)


### PR DESCRIPTION
## Summary
- add `FeedbackRepository` to store user feedback in Firestore
- save feedback from `FeedbackDialogView` using the new repository

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_68702ee7da14833080958369115611dc