### PR TITLE
Add exercise log support

### DIFF
--- a/InnovaFit/Repository/ExerciseLogRepository.swift
+++ b/InnovaFit/Repository/ExerciseLogRepository.swift
@@ -1,0 +1,69 @@
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class ExerciseLogRepository {
+    static private let collection = Firestore.firestore().collection("exercise_logs")
+
+    /// Registra un ejercicio para el usuario actual si no existe uno en la fecha actual.
+    /// - Parameters:
+    ///   - video: Video que se reprodujo.
+    ///   - machine: Máquina asociada al video.
+    ///   - completion: Callback con `true` si se registró un nuevo log.
+    static func registerLogIfNeeded(
+        video: Video,
+        machine: Machine,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) {
+        guard let userId = Auth.auth().currentUser?.uid,
+              let machineId = machine.id else {
+            completion(.failure(NSError(
+                domain: "ExerciseLogRepository",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Usuario o máquina inválidos"]
+            )))
+            return
+        }
+
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: Date())
+        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
+            completion(.failure(NSError(
+                domain: "ExerciseLogRepository",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "No se pudo calcular fin de día"]
+            )))
+            return
+        }
+
+        collection
+            .whereField("userId", isEqualTo: userId)
+            .whereField("videoId", isEqualTo: video.id)
+            .whereField("timestamp", isGreaterThanOrEqualTo: Timestamp(date: startOfDay))
+            .whereField("timestamp", isLessThan: Timestamp(date: endOfDay))
+            .getDocuments { snapshot, error in
+                if let error { completion(.failure(error)); return }
+
+                if let count = snapshot?.documents.count, count > 0 {
+                    completion(.success(false))
+                    return
+                }
+
+                let data: [String: Any] = [
+                    "userId": userId,
+                    "videoId": video.id,
+                    "videoTitle": video.title,
+                    "machineId": machineId,
+                    "machineName": machine.name,
+                    "muscleGroups": Array(video.musclesWorked.keys),
+                    "timestamp": FieldValue.serverTimestamp()
+                ]
+
+                collection.addDocument(data: data) { error in
+                    if let error { completion(.failure(error)) }
+                    else { completion(.success(true)) }
+                }
+            }
+    }
+}
+

--- a/InnovaFit/Views/SegmentedVideoPlayerView.swift
+++ b/InnovaFit/Views/SegmentedVideoPlayerView.swift
@@ -45,6 +45,7 @@ struct SegmentedVideoPlayerView: View {
                     
                     Button(action: {
                                 dismiss()
+                                onDismiss()
                             }) {
                                 Text("×")
                                     .font(.system(size: 30))

--- a/InnovaFit/Views/VideoPlayerView.swift
+++ b/InnovaFit/Views/VideoPlayerView.swift
@@ -5,6 +5,8 @@ struct VideoPlayerView: View {
     let video: Video
     var onDismiss: () -> Void
 
+    @Environment(\.dismiss) private var dismiss
+
     @State private var queuePlayer: AVQueuePlayer?
     @State private var looper: AVPlayerLooper?
 
@@ -30,6 +32,7 @@ struct VideoPlayerView: View {
 
             // Botón de cierre
             Button(action: {
+                dismiss()
                 onDismiss()
             }) {
                 Image(systemName: "xmark.circle.fill")


### PR DESCRIPTION
## Summary
- add `ExerciseLogRepository` to store exercise logs in Firestore
- prompt to add exercise to history when closing a video
- call new repository from alert dialog in `MachineScreenContent2`

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_687153aa86648330822f3abd8105f02a