### PR TITLE
Add muscle history screen

### DIFF
--- a/InnovaFit/Models/ExerciseLog.swift
+++ b/InnovaFit/Models/ExerciseLog.swift
@@ -1,0 +1,14 @@
+import Foundation
+import FirebaseFirestore
+
+/// Registro de un ejercicio completado por el usuario
+struct ExerciseLog: Identifiable, Codable {
+    @DocumentID var id: String?
+    let machineId: String
+    let machineName: String
+    let muscleGroups: [String]
+    let timestamp: Date
+    let userId: String
+    let videoId: String
+    let videoTitle: String
+}

--- a/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
+++ b/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
@@ -1,0 +1,55 @@
+import Foundation
+import SwiftUI
+
+class MuscleHistoryViewModel: ObservableObject {
+    @Published var logs: [ExerciseLog] = []
+
+    func fetchLogs() {
+        ExerciseLogRepository.fetchLogsForCurrentUser { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let logs):
+                    self?.logs = logs
+                case .failure(let error):
+                    print("Error fetching logs: \(error)")
+                    self?.logs = []
+                }
+            }
+        }
+    }
+
+    var muscleDistribution: [MuscleShare] {
+        var counts: [String: Int] = [:]
+        for log in logs {
+            for group in log.muscleGroups {
+                counts[group, default: 0] += 1
+            }
+        }
+        return counts.map { key, value in
+            MuscleShare(muscle: key, count: value)
+        }
+    }
+
+    var recentLogs: [ExerciseLog] {
+        Array(logs.sorted { $0.timestamp > $1.timestamp }.prefix(5))
+    }
+}
+
+struct MuscleShare: Identifiable {
+    var id: String { muscle }
+    let muscle: String
+    let count: Int
+
+    var color: Color {
+        switch muscle.lowercased() {
+        case "cuádriceps", "cuadriceps":
+            return .yellow
+        case "glúteos", "gluteos":
+            return .blue
+        case "espalda":
+            return .green
+        default:
+            return .gray
+        }
+    }
+}

--- a/InnovaFit/Views/MuscleHistoryView.swift
+++ b/InnovaFit/Views/MuscleHistoryView.swift
@@ -1,30 +1,125 @@
-//
-//  MuscleHistoryView.swift
-//  InnovaFit
-//
-//  Created by Fernando Pretell Lozano on 11/07/25.
-//
-
-
 import SwiftUI
+import Charts
 
 struct MuscleHistoryView: View {
+    @StateObject private var viewModel = MuscleHistoryViewModel()
+
     var body: some View {
-        VStack {
-            Text("Historial de músculos trabajados")
-                .font(.title2)
-                .fontWeight(.bold)
-                .foregroundColor(.textTitle)
-                .padding()
-
-            Spacer()
-
-            Text("Aquí se mostrará el historial próximamente...")
-                .font(.subheadline)
-                .foregroundColor(.gray)
-
-            Spacer()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                pieChartSection
+                recentSection
+            }
+            .padding()
         }
         .background(Color.white.ignoresSafeArea())
+        .onAppear { viewModel.fetchLogs() }
     }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Historial de músculos entrenados")
+                .font(.title2.bold())
+                .foregroundColor(.textTitle)
+            Text("Revisa qué grupos musculares has trabajado en tus sesiones.")
+                .font(.subheadline)
+                .foregroundColor(.textSubtitle)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var pieChartSection: some View {
+        VStack(alignment: .leading) {
+            if viewModel.logs.isEmpty {
+                Text("Sin registros disponibles")
+                    .font(.subheadline)
+                    .foregroundColor(.textBody)
+                    .frame(height: 200)
+                    .frame(maxWidth: .infinity)
+            } else {
+                Chart(viewModel.muscleDistribution) { item in
+                    SectorMark(angle: .value("Sesiones", item.count))
+                        .foregroundStyle(item.color)
+                }
+                .chartLegend(.hidden)
+                .frame(height: 220)
+                .overlay(
+                    Text("\(viewModel.logs.count)")
+                        .font(.title.bold())
+                        .foregroundColor(.textTitle)
+                )
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color.white)
+        .cornerRadius(16)
+        .shadow(color: Color.black.opacity(0.05), radius: 3, x: 0, y: 2)
+    }
+
+    private var recentSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Sesiones recientes")
+                .font(.headline)
+                .foregroundColor(.textTitle)
+            ForEach(viewModel.recentLogs) { log in
+                SessionRow(log: log)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct SessionRow: View {
+    let log: ExerciseLog
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "dumbbell")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 40, height: 40)
+                .padding(6)
+                .background(Color.backgroundFields)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(log.machineName)
+                    .font(.subheadline.bold())
+                    .foregroundColor(.textTitle)
+                Text(log.muscleGroups.joined(separator: ", "))
+                    .font(.caption)
+                    .foregroundColor(.textBody)
+                Text(log.timestamp, style: .time)
+                    .font(.caption2)
+                    .foregroundColor(.textSubtitle)
+            }
+            Spacer()
+            VStack(spacing: 12) {
+                Button {
+                    // Acción para volver a la rutina
+                } label: {
+                    Image(systemName: "arrow.uturn.backward")
+                }
+                ShareLink(item: "Entrené \(log.videoTitle)") {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+            .buttonStyle(BorderlessButtonStyle())
+            .foregroundColor(.accentColor)
+        }
+        .padding()
+        .background(Color.white)
+        .cornerRadius(12)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.black.opacity(0.06), lineWidth: 1)
+        )
+        .shadow(color: Color.black.opacity(0.05), radius: 2, x: 0, y: 2)
+    }
+}
+
+#Preview {
+    MuscleHistoryView()
 }


### PR DESCRIPTION
## Summary
- define `ExerciseLog` model
- update `ExerciseLogRepository` with Firestore collection `exercise_log` and add log fetch method
- implement `MuscleHistoryViewModel` for fetching and aggregating logs
- create new `MuscleHistoryView` with pie chart and recent sessions

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752c933a848330ae847ef89918f402