### PR TITLE
Fix donut chart clipping

### DIFF
--- a/InnovaFit/Utils/DonutSegment.swift
+++ b/InnovaFit/Utils/DonutSegment.swift
@@ -11,32 +11,39 @@ struct DonutChartView: View {
     let total: Int
 
     var body: some View {
-        ZStack {
-            // Dibuja cada segmento manualmente, acumulando los "offsets"
-            ForEach(Array(segments.enumerated()), id: \.element.id) { index, segment in
+        GeometryReader { geo in
+            let size = min(geo.size.width, geo.size.height)
+
+            ZStack {
+                // Dibuja cada segmento manualmente, acumulando los "offsets"
+                ForEach(Array(segments.enumerated()), id: \.element.id) { index, segment in
+                    Circle()
+                        .trim(from: startAngle(for: index), to: endAngle(for: index))
+                        .stroke(
+                            segment.color,
+                            style: StrokeStyle(lineWidth: size * 0.1125, lineCap: .round)
+                        )
+                        .rotationEffect(.degrees(-90))
+                        .frame(width: size, height: size)
+                }
+
+                // El centro (blanco, para el hueco del donut)
                 Circle()
-                    .trim(from: startAngle(for: index), to: endAngle(for: index))
-                    .stroke(segment.color, style: StrokeStyle(lineWidth: 18, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                    .frame(width: 160, height: 160)
-            }
+                    .fill(Color.white)
+                    .frame(width: size * 0.6875, height: size * 0.6875)
 
-            // El centro (blanco, para el hueco del donut)
-            Circle()
-                .fill(Color.white)
-                .frame(width: 110, height: 110)
-
-            // Texto central
-            VStack(spacing: 0) {
-                Text("\(total)")
-                    .font(.system(size: 32, weight: .bold))
-                    .foregroundColor(.black)
-                Text("Sesiones")
-                    .font(.subheadline)
-                    .foregroundColor(.gray)
+                // Texto central
+                VStack(spacing: 0) {
+                    Text("\(total)")
+                        .font(.system(size: size * 0.2, weight: .bold))
+                        .foregroundColor(.black)
+                    Text("Sesiones")
+                        .font(.subheadline)
+                        .foregroundColor(.gray)
+                }
             }
+            .frame(width: size, height: size)
         }
-        .frame(width: 150, height: 150)
     }
 
     // Helpers para ángulos acumulados


### PR DESCRIPTION
## Summary
- ensure donut chart internal frames match external size to avoid clipping

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*
- `bash run_tests.sh` *(fails: xcodebuild: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756cdcc4c08330a18d70fd714e2860