### PR TITLE
Add machine image to ExerciseLog and filter logs by week

### DIFF
--- a/InnovaFit/Models/ExerciseLog.swift
+++ b/InnovaFit/Models/ExerciseLog.swift
@@ -14,6 +14,7 @@ struct ExerciseLog: Identifiable, Codable {
     @DocumentID var id: String?
     let machineId: String
     let machineName: String
+    let machineImageUrl: String
     let muscleGroups: [String]
     let timestamp: Date
     let userId: String

--- a/InnovaFit/Repository/ExerciseLogRepository.swift
+++ b/InnovaFit/Repository/ExerciseLogRepository.swift
@@ -55,6 +55,7 @@ class ExerciseLogRepository {
                     "videoTitle": video.title,
                     "machineId": machineId,
                     "machineName": machine.name,
+                    "machineImageUrl": machine.imageUrl,
                     "muscleGroups": Array(video.musclesWorked.keys),
                     "timestamp": FieldValue.serverTimestamp()
                 ]
@@ -74,8 +75,18 @@ class ExerciseLogRepository {
             return
         }
         
+        var calendar = Calendar.current
+        // Establecer lunes como primer día de la semana
+        calendar.firstWeekday = 2
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
+        guard let startOfWeek = calendar.date(from: components) else {
+            completion(.success([]))
+            return
+        }
+
         collection
             .whereField("userId", isEqualTo: userId)
+            .whereField("timestamp", isGreaterThanOrEqualTo: Timestamp(date: startOfWeek))
             .order(by: "timestamp", descending: true)
             .getDocuments { snapshot, error in
                 if let error { completion(.failure(error)); return }

--- a/InnovaFit/Views/MuscleHistoryView.swift
+++ b/InnovaFit/Views/MuscleHistoryView.swift
@@ -146,13 +146,16 @@ struct SessionRow: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            Image(systemName: "dumbbell")
-                .resizable()
-                .scaledToFit()
-                .frame(width: 40, height: 40)
-                .padding(6)
-                .background(Color.backgroundFields)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+            AsyncImage(url: URL(string: log.machineImageUrl)) { phase in
+                if let image = phase.image {
+                    image.resizable().scaledToFill()
+                } else {
+                    Color.backgroundFields
+                }
+            }
+            .frame(width: 40, height: 40)
+            .clipped()
+            .cornerRadius(8)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(log.machineName)


### PR DESCRIPTION
## Summary
- include `machineImageUrl` in `ExerciseLog`
- store the machine image url when creating logs
- filter log queries to only fetch data from the current week
- display machine image in `MuscleHistoryView`

## Testing
- `./run_tests.sh` *(fails: `xcodebuild: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687590456e6083308a53616add441bcf