### PR TITLE
Ensure session rows share legend colors

### DIFF
--- a/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
+++ b/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
@@ -84,5 +84,9 @@ extension MuscleHistoryViewModel {
             DonutSegment(percent: Double(share.count) / Double(total), color: share.color)
         }
     }
-    
+
+    func color(for muscle: String) -> Color {
+        muscleDistribution.first(where: { $0.muscle == muscle })?.color ?? Color(hex: "#E1E3E8")
+    }
+
 }

--- a/InnovaFit/Views/MuscleHistoryView.swift
+++ b/InnovaFit/Views/MuscleHistoryView.swift
@@ -132,7 +132,10 @@ struct MuscleHistoryView: View {
                 .fontWeight(.heavy)
                 .foregroundColor(.textTitle)
             ForEach(viewModel.recentLogs) { log in
-                SessionRow(log: log)
+                SessionRow(
+                    log: log,
+                    muscleColor: viewModel.color(for: log.muscleGroups.first ?? "")
+                )
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -142,6 +145,7 @@ struct MuscleHistoryView: View {
 // MARK: - Row de sesión
 struct SessionRow: View {
     let log: ExerciseLog
+    let muscleColor: Color
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -167,7 +171,7 @@ struct SessionRow: View {
                 if let mainMuscle = log.muscleGroups.first {
                     Text("\(mainMuscle)")
                         .font(.subheadline.weight(.bold))
-                        .foregroundColor(Color(hex: "#F9C534")) // Naranja
+                        .foregroundColor(muscleColor)
                         .padding(.top, 2)
                 }
             }


### PR DESCRIPTION
## Summary
- ensure recent session rows use the same color mapping as the legend
- expose `color(for:)` helper in the view model

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_687726d17e1c8330967326a1eeea54f6