### PR TITLE
Add selfie share button

### DIFF
--- a/InnovaFit/Views/SelfieCameraView.swift
+++ b/InnovaFit/Views/SelfieCameraView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct SelfieCameraView: UIViewControllerRepresentable {
+    var onImage: (UIImage) -> Void
+    @Environment(\.presentationMode) private var presentationMode
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        if UIImagePickerController.isCameraDeviceAvailable(.front) {
+            picker.cameraDevice = .front
+        }
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        let parent: SelfieCameraView
+
+        init(parent: SelfieCameraView) {
+            self.parent = parent
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.onImage(image)
+            }
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.presentationMode.wrappedValue.dismiss()
+        }
+    }
+}

--- a/InnovaFit/Views/ShareSheet.swift
+++ b/InnovaFit/Views/ShareSheet.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}


### PR DESCRIPTION
## Summary
- add state for selfie sharing in MuscleHistoryView
- place a share button beside the "Sesiones recientes" header
- show camera and share sheet when sharing
- create helper to compose share image
- add SelfieCameraView and ShareSheet utilities

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772d4c41fc83308189ab62da08b053