### PR TITLE
Add selfie processing overlay and share composition

### DIFF
--- a/InnovaFit.xcodeproj/project.pbxproj
+++ b/InnovaFit.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		DE9BF5D62DDE8C8B00094A0D /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = DE9BF5D52DDE8C8B00094A0D /* SDWebImageSwiftUI */; };
 		DEA9BE142DFB5F7400E18AD5 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = DEA9BE132DFB5F7400E18AD5 /* ViewInspector */; };
 		DEA9BE162DFB5FD100E18AD5 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = DEA9BE152DFB5FD100E18AD5 /* ViewInspector */; };
+		DEBF2B452E27E57F00CBEE86 /* Vision.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEBF2B442E27E57F00CBEE86 /* Vision.framework */; };
+		DEBF2B472E27E5BA00CBEE86 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEBF2B462E27E5BA00CBEE86 /* CoreImage.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +48,8 @@
 		DE9BF5862DDE564400094A0D /* InnovaFit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InnovaFit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE9BF5952DDE564700094A0D /* InnovaFitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InnovaFitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE9BF59F2DDE564700094A0D /* InnovaFitUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InnovaFitUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DEBF2B442E27E57F00CBEE86 /* Vision.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Vision.framework; path = System/Library/Frameworks/Vision.framework; sourceTree = SDKROOT; };
+		DEBF2B462E27E5BA00CBEE86 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = System/Library/Frameworks/CoreImage.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -96,6 +100,8 @@
 				DE9BF5C32DDE6ECB00094A0D /* FirebaseCrashlytics in Frameworks */,
 				DE9BF5C12DDE6ECB00094A0D /* FirebaseCore in Frameworks */,
 				DE9BF5C52DDE6ECB00094A0D /* FirebaseFirestore in Frameworks */,
+				DEBF2B472E27E5BA00CBEE86 /* CoreImage.framework in Frameworks */,
+				DEBF2B452E27E57F00CBEE86 /* Vision.framework in Frameworks */,
 				DE9BF5BF2DDE6ECB00094A0D /* FirebaseAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -129,6 +135,7 @@
 				DE9BF5882DDE564400094A0D /* InnovaFit */,
 				DE9BF5982DDE564700094A0D /* InnovaFitTests */,
 				DE9BF5A22DDE564700094A0D /* InnovaFitUITests */,
+				DEBF2B432E27E57E00CBEE86 /* Frameworks */,
 				DE9BF5872DDE564400094A0D /* Products */,
 			);
 			sourceTree = "<group>";
@@ -141,6 +148,15 @@
 				DE9BF59F2DDE564700094A0D /* InnovaFitUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		DEBF2B432E27E57E00CBEE86 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DEBF2B462E27E5BA00CBEE86 /* CoreImage.framework */,
+				DEBF2B442E27E57F00CBEE86 /* Vision.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/InnovaFit/Utils/UIImage+BackgroundRemoval.swift
+++ b/InnovaFit/Utils/UIImage+BackgroundRemoval.swift
@@ -1,0 +1,25 @@
+import UIKit
+import Vision
+import CoreImage
+
+extension UIImage {
+    func removingBackground() async -> UIImage? {
+        guard let cgImage = self.cgImage else { return nil }
+        let request = VNGeneratePersonSegmentationRequest()
+        request.qualityLevel = .balanced
+        request.outputPixelFormat = kCVPixelFormatType_OneComponent8
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        do {
+            try handler.perform([request])
+            guard let maskBuffer = request.results?.first?.pixelBuffer else { return nil }
+            let maskImage = CIImage(cvPixelBuffer: maskBuffer)
+            let original = CIImage(cgImage: cgImage)
+            let result = original.applyingFilter("CIBlendWithMask", parameters: [kCIInputMaskImageKey: maskImage])
+            let context = CIContext()
+            guard let cgResult = context.createCGImage(result, from: original.extent) else { return nil }
+            return UIImage(cgImage: cgResult)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/InnovaFit/Utils/UIImage+BackgroundRemoval.swift
+++ b/InnovaFit/Utils/UIImage+BackgroundRemoval.swift
@@ -4,22 +4,52 @@ import CoreImage
 
 extension UIImage {
     func removingBackground() async -> UIImage? {
-        guard let cgImage = self.cgImage else { return nil }
+        print("[BG_REMOVAL] Inicio de removingBackground()")
+        guard let cgImage = self.cgImage else {
+            print("[BG_REMOVAL] ❌ No CGImage disponible")
+            return nil
+        }
         let request = VNGeneratePersonSegmentationRequest()
         request.qualityLevel = .balanced
         request.outputPixelFormat = kCVPixelFormatType_OneComponent8
+
         let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
         do {
+            print("[BG_REMOVAL] Ejecutando request de segmentación…")
             try handler.perform([request])
-            guard let maskBuffer = request.results?.first?.pixelBuffer else { return nil }
+
+            guard
+                let results = request.results,
+                let maskBuffer = results.first?.pixelBuffer
+            else {
+                print("[BG_REMOVAL] ❌ No se obtuvo pixelBuffer del mask")
+                return nil
+            }
+            print("[BG_REMOVAL] ✅ Mask buffer obtenido: tamaño \(CVPixelBufferGetWidth(maskBuffer))x\(CVPixelBufferGetHeight(maskBuffer))")
+
+            // Convertir a CIImage
             let maskImage = CIImage(cvPixelBuffer: maskBuffer)
             let original = CIImage(cgImage: cgImage)
-            let result = original.applyingFilter("CIBlendWithMask", parameters: [kCIInputMaskImageKey: maskImage])
+
+            // Aplicar máscara
+            let blended = original.applyingFilter(
+                "CIBlendWithMask",
+                parameters: [kCIInputMaskImageKey: maskImage]
+            )
+            print("[BG_REMOVAL] Composición con máscara aplicada")
+
+            // Crear CGImage de salida
             let context = CIContext()
-            guard let cgResult = context.createCGImage(result, from: original.extent) else { return nil }
-            return UIImage(cgImage: cgResult)
+            guard let cgResult = context.createCGImage(blended, from: original.extent) else {
+                print("[BG_REMOVAL] ❌ No se pudo crear CGImage de resultado")
+                return nil
+            }
+            print("[BG_REMOVAL] ✅ CGImage de resultado creado, devolviendo UIImage final")
+            return UIImage(cgImage: cgResult, scale: self.scale, orientation: self.imageOrientation)
         } catch {
+            print("[BG_REMOVAL] ❌ Error durante la petición Vision: \(error.localizedDescription)")
             return nil
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- add background removal helper
- show loader while composing selfie share
- create share card with background image and stats overlay

## Testing
- `./run_tests.sh` *(fails: `xcodebuild: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6877a91f64688330b6da4d65098b1375