### PR TITLE
Add splash screen for auth flow

### DIFF
--- a/InnovaFit/ContentView.swift
+++ b/InnovaFit/ContentView.swift
@@ -6,6 +6,8 @@ struct ContentView: View {
     var body: some View {
         NavigationStack {
             switch authViewModel.authState {
+            case .splash:
+                SplashView()
             case .login:
                 LoginView(viewModel: authViewModel)
             case .otp:

--- a/InnovaFit/ViewModels/AuthViewModel.swift
+++ b/InnovaFit/ViewModels/AuthViewModel.swift
@@ -3,6 +3,7 @@ import FirebaseAuth
 
 /// Estados posibles de autenticación
 enum AuthState {
+    case splash
     case login
     case otp
     case register
@@ -15,7 +16,7 @@ class AuthViewModel: ObservableObject {
     @Published var otpCode: String = ""
     @Published var verificationID: String?
     @Published var userProfile: UserProfile?
-    @Published var authState: AuthState = .login
+    @Published var authState: AuthState = .splash
     @Published var gyms: [Gym] = []
 
     private let repository = UserRepository()
@@ -37,6 +38,8 @@ class AuthViewModel: ObservableObject {
                     }
                 }
             }
+        } else {
+            authState = .login
         }
     }
 

--- a/InnovaFit/Views/SplashView.swift
+++ b/InnovaFit/Views/SplashView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Simple splash view while determining authentication state
+struct SplashView: View {
+    var body: some View {
+        ZStack {
+            Color.white.ignoresSafeArea()
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle(tint: .accentColor))
+                .scaleEffect(1.5)
+        }
+    }
+}
+
+#Preview {
+    SplashView()
+}


### PR DESCRIPTION
## Summary
- show a new `SplashView` while checking current user
- default `AuthViewModel` to a `.splash` state and switch to `.login` only when needed
- update `ContentView` to include the splash case

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68795df9b5208330a327d8ef6bc28be8