### PR TITLE
Fix universal link navigation

### DIFF
--- a/InnovaFit/Views/MainTabView.swift
+++ b/InnovaFit/Views/MainTabView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct MainTabView: View {
     @ObservedObject var viewModel: AuthViewModel
+    @EnvironmentObject private var appDelegate: AppDelegate
     @StateObject private var machineVM = MachineViewModel()
     @State private var selectedTab: Tab = .home
     @State private var navigationPath: [TabsRoute] = []
@@ -76,6 +77,18 @@ struct MainTabView: View {
                             }
                         }
                     }
+                }
+            }
+            .onAppear {
+                if let tag = appDelegate.pendingTag {
+                    machineVM.loadDataFromTag(tag)
+                    appDelegate.pendingTag = nil
+                }
+            }
+            .onChange(of: appDelegate.pendingTag) { _, newValue in
+                if let tag = newValue {
+                    machineVM.loadDataFromTag(tag)
+                    appDelegate.pendingTag = nil
                 }
             }
             .onChange(of: machineVM.hasLoadedTag) { _, newValue in


### PR DESCRIPTION
## Summary
- access `AppDelegate` inside `MainTabView`
- trigger machine load when a universal link tag is received

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6879d9aec5388330878f5bd736f9e161