### PR TITLE
Implement universal link navigation

### DIFF
--- a/InnovaFit/InnovaFitApp.swift
+++ b/InnovaFit/InnovaFitApp.swift
@@ -11,7 +11,7 @@ import FirebaseAuth
 class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
     @Published var pendingTag: String?
-    var didLaunchViaUniversalLink: Bool = false
+    @Published var didLaunchViaUniversalLink: Bool = false
     
     func application(
         _ application: UIApplication,

--- a/InnovaFit/Views/MainTabView.swift
+++ b/InnovaFit/Views/MainTabView.swift
@@ -67,24 +67,35 @@ struct MainTabView: View {
                 }
             }
             .onAppear {
-                if let tag = appDelegate.pendingTag {
+                if appDelegate.didLaunchViaUniversalLink,
+                   let tag = appDelegate.pendingTag {
+                    // Ensure we start from the Home tab
+                    selectedTab = .home
                     machineVM.loadDataFromTag(tag)
                     appDelegate.pendingTag = nil
                 }
             }
             .onChange(of: appDelegate.pendingTag) { _, newValue in
-                if let tag = newValue {
+                if appDelegate.didLaunchViaUniversalLink,
+                   let tag = newValue {
+                    // Ensure we start from the Home tab
+                    selectedTab = .home
                     machineVM.loadDataFromTag(tag)
                     appDelegate.pendingTag = nil
                 }
             }
             .onChange(of: machineVM.hasLoadedTag) { _, newValue in
                 if newValue {
+                    // Always display the machine from the Home tab
+                    selectedTab = .home
+
                     if let machine = machineVM.machine, let gym = machineVM.gym {
                         navigationPath.append(.machine(machine: machine, gym: gym))
                     } else {
                         showErrorAlert = true
                     }
+
+                    appDelegate.didLaunchViaUniversalLink = false
                     machineVM.hasLoadedTag = false
                 }
             }


### PR DESCRIPTION
## Summary
- only auto-navigate to machine screen when universal link launches the app
- track universal link flag via AppDelegate
- open machines from the Home tab when navigating

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b223e47248330b1b4e8a9a5f6cb0c