### PR TITLE
Add logs for universal link flow

### DIFF
--- a/InnovaFit/InnovaFitApp.swift
+++ b/InnovaFit/InnovaFitApp.swift
@@ -18,6 +18,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         print("🚀 AppDelegate: aplicación lanzó")
+        print("🔗 Launch options: \(launchOptions ?? [:])")
         FirebaseApp.configure()
         
         // 🔐 Solicita permiso de notificaciones push
@@ -28,6 +29,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
            activity.activityType == NSUserActivityTypeBrowsingWeb,
            let url = activity.webpageURL,
            let tag = extractTag(from: url) {
+            print("📡 Universal link detectado al lanzar: \(url.absoluteString)")
             pendingTag = tag
             didLaunchViaUniversalLink = true
         } else {
@@ -39,11 +41,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
     func application(_ application: UIApplication,
                      continue userActivity: NSUserActivity,
                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+
+        print("➡️ Continue userActivity called with: \(userActivity.activityType) - URL: \(userActivity.webpageURL?.absoluteString ?? "nil")")
         
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
            let url = userActivity.webpageURL,
            let tag = extractTag(from: url) {
-
             print("📲 AppDelegate recibió tag por Universal Link: \(tag)")
             self.pendingTag = tag
             didLaunchViaUniversalLink = true
@@ -89,10 +92,14 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
     private func extractTag(from url: URL) -> String? {
         if let components = URLComponents(url: url, resolvingAgainstBaseURL: true) {
             if let item = components.queryItems?.first(where: { $0.name.lowercased() == "tag" }) {
-                return item.value
+                let tagValue = item.value
+                print("🔎 extractTag query item result: \(tagValue ?? "nil")")
+                return tagValue
             }
             let lastPath = components.path.split(separator: "/").last
-            return lastPath.map { String($0) }
+            let pathTag = lastPath.map { String($0) }
+            print("🔎 extractTag path result: \(pathTag ?? "nil")")
+            return pathTag
         }
         return nil
     }

--- a/InnovaFit/Repository/MachineRepository.swift
+++ b/InnovaFit/Repository/MachineRepository.swift
@@ -29,6 +29,7 @@ class MachineRepository {
     /// Carga un `Machine` desde Firestore dado su `machineId`.
     static func loadMachine(machineId: String, completion: @escaping (Machine?) -> Void) {
         let db = Firestore.firestore()
+        print("📥 Loading Machine with id: \(machineId)")
         db.collection("machines").document(machineId).getDocument { snapshot, error in
             guard let doc = snapshot, error == nil else {
                 print("❌ Error al cargar Machine: \(error?.localizedDescription ?? "desconocido")")
@@ -39,6 +40,7 @@ class MachineRepository {
             do {
                 // Aquí Firestore usa el modelo Machine para decodificar JSON automáticamente
                 let machine = try doc.data(as: Machine.self)
+                print("✅ Machine loaded: \(machine.name)")
                 completion(machine)
             } catch {
                 print("❌ Error al parsear Machine: \(error)")
@@ -50,6 +52,7 @@ class MachineRepository {
     /// Carga un `Gym` desde Firestore dado su `gymId`.
     static func loadGym(gymId: String, completion: @escaping (Gym?) -> Void) {
         let db = Firestore.firestore()
+        print("📥 Loading Gym with id: \(gymId)")
         db.collection("gyms").document(gymId).getDocument { snapshot, error in
             guard let doc = snapshot, error == nil else {
                 print("❌ Error al cargar Gym: \(error?.localizedDescription ?? "desconocido")")
@@ -59,6 +62,7 @@ class MachineRepository {
 
             do {
                 let gym = try doc.data(as: Gym.self)
+                print("✅ Gym loaded: \(gym.name)")
                 completion(gym)
             } catch {
                 print("❌ Error al parsear Gym: \(error)")

--- a/InnovaFit/ViewModels/MachineViewModel.swift
+++ b/InnovaFit/ViewModels/MachineViewModel.swift
@@ -14,6 +14,7 @@ class MachineViewModel: ObservableObject {
     
 
     func loadDataFromTag(_ tag: String) {
+        print("🚚 loadDataFromTag called with tag: \(tag)")
         self.tag = tag
         self.isLoading = true
         self.errorMessage = nil
@@ -21,6 +22,8 @@ class MachineViewModel: ObservableObject {
 
         MachineRepository.resolveTag(tag: tag) { [weak self] gymId, machineId in
             guard let self = self else { return }
+
+            print("🧭 resolveTag result gymId: \(gymId ?? "nil"), machineId: \(machineId ?? "nil")")
 
             guard let gymId = gymId, let machineId = machineId else {
                 DispatchQueue.main.async {
@@ -49,6 +52,7 @@ class MachineViewModel: ObservableObject {
             }
 
             group.notify(queue: .main) {
+                print("🏋️‍♂️ Loaded gym: \(loadedGym?.name ?? "nil"), machine: \(loadedMachine?.name ?? "nil")")
                 self.gym = loadedGym
                 self.machine = loadedMachine
                 self.isLoading = false

--- a/InnovaFit/Views/MainTabView.swift
+++ b/InnovaFit/Views/MainTabView.swift
@@ -67,29 +67,35 @@ struct MainTabView: View {
                 }
             }
             .onAppear {
+                print("🟢 MainTabView onAppear - didLaunchViaUniversalLink: \(appDelegate.didLaunchViaUniversalLink), tag: \(appDelegate.pendingTag ?? "nil")")
                 if appDelegate.didLaunchViaUniversalLink,
                    let tag = appDelegate.pendingTag {
                     // Ensure we start from the Home tab
                     selectedTab = .home
+                    print("🚀 Cargando datos para tag en onAppear: \(tag)")
                     machineVM.loadDataFromTag(tag)
                     appDelegate.pendingTag = nil
                 }
             }
             .onChange(of: appDelegate.pendingTag) { _, newValue in
+                print("🔄 pendingTag cambió a: \(newValue ?? "nil")")
                 if appDelegate.didLaunchViaUniversalLink,
                    let tag = newValue {
                     // Ensure we start from the Home tab
                     selectedTab = .home
+                    print("🚀 Cargando datos para tag desde onChange: \(tag)")
                     machineVM.loadDataFromTag(tag)
                     appDelegate.pendingTag = nil
                 }
             }
             .onChange(of: machineVM.hasLoadedTag) { _, newValue in
+                print("📦 hasLoadedTag cambió a: \(newValue)")
                 if newValue {
                     // Always display the machine from the Home tab
                     selectedTab = .home
 
                     if let machine = machineVM.machine, let gym = machineVM.gym {
+                        print("✅ Navegando a MachineScreenContent2")
                         navigationPath.append(.machine(machine: machine, gym: gym))
                     } else {
                         showErrorAlert = true

--- a/InnovaFit/Views/QRScannerView.swift
+++ b/InnovaFit/Views/QRScannerView.swift
@@ -29,6 +29,7 @@ struct QRScannerView: UIViewControllerRepresentable {
         func didFind(code: String) {
             guard !hasScanned else { return }
             hasScanned = true
+            print("📸 Código QR detectado: \(code)")
             DispatchQueue.main.async {
                 self.parent.onFound(code)
             }


### PR DESCRIPTION
## Summary
- log launch options and universal link events in `AppDelegate`
- add debug prints throughout machine loading
- trace universal-link handling inside `MainTabView`
- print scanned codes

## Testing
- `./run_tests.sh` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c40ca4134833097b8a2d4d5632f44