### PR TITLE
Save primary muscle group in exercise logs

### DIFF
--- a/InnovaFit/Models/ExerciseLog.swift
+++ b/InnovaFit/Models/ExerciseLog.swift
@@ -15,7 +15,8 @@ struct ExerciseLog: Identifiable, Codable {
     let machineId: String
     let machineName: String
     let machineImageUrl: String
-    let muscleGroups: [String]
+    /// Grupo muscular principal trabajado en el ejercicio
+    let muscleGroup: String
     let timestamp: Date
     let userId: String
     let videoId: String

--- a/InnovaFit/Repository/ExerciseLogRepository.swift
+++ b/InnovaFit/Repository/ExerciseLogRepository.swift
@@ -49,6 +49,9 @@ class ExerciseLogRepository {
                     return
                 }
 
+                let primaryMuscle = video.musclesWorked
+                    .max { $0.value.weight < $1.value.weight }?.key ?? ""
+
                 let data: [String: Any] = [
                     "userId": userId,
                     "videoId": video.id,
@@ -56,7 +59,7 @@ class ExerciseLogRepository {
                     "machineId": machineId,
                     "machineName": machine.name,
                     "machineImageUrl": machine.imageUrl,
-                    "muscleGroups": Array(video.musclesWorked.keys),
+                    "muscleGroup": primaryMuscle,
                     "timestamp": FieldValue.serverTimestamp()
                 ]
 

--- a/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
+++ b/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
@@ -22,9 +22,7 @@ class MuscleHistoryViewModel: ObservableObject {
     var muscleDistribution: [MuscleShare] {
         var counts: [String: Int] = [:]
         for log in logs {
-            if let mainMuscle = log.muscleGroups.first {
-                counts[mainMuscle, default: 0] += 1
-            }
+            counts[log.muscleGroup, default: 0] += 1
         }
         // Ordenar de mayor a menor y de forma estable cuando hay empates
         let sorted = counts.sorted { lhs, rhs in

--- a/InnovaFit/Views/CardForShareView.swift
+++ b/InnovaFit/Views/CardForShareView.swift
@@ -27,9 +27,7 @@ struct CardForShareView: View {
         // Cuenta por músculo principal
         var counts: [String:Int] = [:]
         logs.forEach { log in
-            if let m = log.muscleGroups.first {
-                counts[m, default: 0] += 1
-            }
+            counts[log.muscleGroup, default: 0] += 1
         }
         let palette: [Color] = [ .orange, .blue, .green, .red, .purple ]
         return counts
@@ -164,7 +162,7 @@ struct CardForShareView_Previews: PreviewProvider {
                 machineId: "legpress",
                 machineName: "Leg Press \(index)",
                 machineImageUrl: "https://placekitten.com/200/200",
-                muscleGroups: ["Cuádriceps"],
+                muscleGroup: "Cuádriceps",
                 timestamp: Date().addingTimeInterval(Double(-index * 3600)),
                 userId: "user123",
                 videoId: "vid_quad_\(index)",
@@ -178,7 +176,7 @@ struct CardForShareView_Previews: PreviewProvider {
                 machineId: "adductor",
                 machineName: "Adductor Machine \(index)",
                 machineImageUrl: "https://placekitten.com/200/200",
-                muscleGroups: ["Aductores"],
+                muscleGroup: "Aductores",
                 timestamp: Date().addingTimeInterval(Double(-index * 7200)),
                 userId: "user123",
                 videoId: "vid_adduct_\(index)",

--- a/InnovaFit/Views/WeeklyEvolutionCardView.swift
+++ b/InnovaFit/Views/WeeklyEvolutionCardView.swift
@@ -33,9 +33,7 @@ struct WeeklyEvolutionCardView: View {
         // Cuenta por músculo principal
         var counts: [String:Int] = [:]
         logs.forEach { log in
-            if let m = log.muscleGroups.first {
-                counts[m, default: 0] += 1
-            }
+            counts[log.muscleGroup, default: 0] += 1
         }
         let palette: [Color] = [ .orange, .blue, .green, .red, .purple ]
         return counts
@@ -171,7 +169,7 @@ struct WeeklyEvolutionCardView_Previews: PreviewProvider {
                 machineId: "legpress",
                 machineName: "Leg Press \(index)",
                 machineImageUrl: "https://placekitten.com/200/200",
-                muscleGroups: ["Cuádriceps"],
+                muscleGroup: "Cuádriceps",
                 timestamp: Date().addingTimeInterval(Double(-index * 3600)),
                 userId: "user123",
                 videoId: "vid_quad_\(index)",
@@ -185,7 +183,7 @@ struct WeeklyEvolutionCardView_Previews: PreviewProvider {
                 machineId: "adductor",
                 machineName: "Adductor Machine \(index)",
                 machineImageUrl: "https://placekitten.com/200/200",
-                muscleGroups: ["Aductores"],
+                muscleGroup: "Aductores",
                 timestamp: Date().addingTimeInterval(Double(-index * 7200)),
                 userId: "user123",
                 videoId: "vid_adduct_\(index)",


### PR DESCRIPTION
## Summary
- Record only the primary muscle group when logging exercises
- Aggregate weekly progress using the single saved muscle

## Testing
- `./run_tests.sh` *(fails: xcodebuild: command not found)*
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6894e89d5fe083308594e02e6f758739