### PR TITLE
Track main muscle in exercise logs

### DIFF
--- a/InnovaFit/Models/ExerciseLog.swift
+++ b/InnovaFit/Models/ExerciseLog.swift
@@ -16,6 +16,8 @@ struct ExerciseLog: Identifiable, Codable {
     let machineName: String
     let machineImageUrl: String
     let muscleGroups: [String]
+    /// Grupo muscular con mayor enfoque del ejercicio
+    let mainMuscle: String = ""
     let timestamp: Date
     let userId: String
     let videoId: String

--- a/InnovaFit/Repository/ExerciseLogRepository.swift
+++ b/InnovaFit/Repository/ExerciseLogRepository.swift
@@ -49,6 +49,10 @@ class ExerciseLogRepository {
                     return
                 }
 
+                let mainMuscle = video.musclesWorked.max { lhs, rhs in
+                    lhs.value.weight < rhs.value.weight
+                }?.key ?? ""
+
                 let data: [String: Any] = [
                     "userId": userId,
                     "videoId": video.id,
@@ -57,6 +61,7 @@ class ExerciseLogRepository {
                     "machineName": machine.name,
                     "machineImageUrl": machine.imageUrl,
                     "muscleGroups": Array(video.musclesWorked.keys),
+                    "mainMuscle": mainMuscle,
                     "timestamp": FieldValue.serverTimestamp()
                 ]
 

--- a/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
+++ b/InnovaFit/ViewModels/MuscleHistoryViewModel.swift
@@ -22,9 +22,7 @@ class MuscleHistoryViewModel: ObservableObject {
     var muscleDistribution: [MuscleShare] {
         var counts: [String: Int] = [:]
         for log in logs {
-            if let mainMuscle = log.muscleGroups.first {
-                counts[mainMuscle, default: 0] += 1
-            }
+            counts[log.mainMuscle, default: 0] += 1
         }
         // Ordenar de mayor a menor y de forma estable cuando hay empates
         let sorted = counts.sorted { lhs, rhs in

--- a/InnovaFit/Views/MuscleHistoryView.swift
+++ b/InnovaFit/Views/MuscleHistoryView.swift
@@ -159,7 +159,7 @@ struct MuscleHistoryView: View {
             ForEach(viewModel.recentLogs) { log in
                 SessionRow(
                     log: log,
-                    muscleColor: viewModel.color(for: log.muscleGroups.first ?? "")
+                    muscleColor: viewModel.color(for: log.mainMuscle)
                 )
             }
         }
@@ -193,8 +193,8 @@ struct SessionRow: View {
                     .foregroundColor(.textBody)
                 
                 // Músculo principal
-                if let mainMuscle = log.muscleGroups.first {
-                    Text("\(mainMuscle)")
+                if !log.mainMuscle.isEmpty {
+                    Text(log.mainMuscle)
                         .font(.subheadline.weight(.bold))
                         .foregroundColor(muscleColor)
                         .padding(.top, 2)

--- a/InnovaFit/Views/ShareCardView.swift
+++ b/InnovaFit/Views/ShareCardView.swift
@@ -28,7 +28,7 @@ struct ShareCardView: View {
     private var segments: [MuscleSegment] {
         var counts: [String: Int] = [:]
         logs.forEach { log in
-            counts[log.muscleGroup, default: 0] += 1
+            counts[log.mainMuscle, default: 0] += 1
         }
 
         let palette: [Color] = [.orange, .blue, .green, .red, .purple]
@@ -42,7 +42,7 @@ struct ShareCardView: View {
     private var totalCount: Int { segments.map(\.count).reduce(0, +) }
     private var featuredExercise: String {
         logs.sorted { $0.timestamp > $1.timestamp }
-            .first?.muscleGroup ?? ""
+            .first?.mainMuscle ?? ""
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- store the main muscle worked in `ExerciseLog`
- compute and save main muscle when registering a log
- use `mainMuscle` for charts and featured exercise in muscle history and share views

## Testing
- `./run_tests.sh` *(fails: xcodebuild: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895231a5bbc8330b4dd2992b9c6d447